### PR TITLE
ci(workflow): 移除未使用的workflow配置项

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,5 +16,3 @@ jobs:
       pnpm-version: 9
       node-version: 22
       java-version: 21
-      skip-node-setup: false
-      artifacts-path: "build/libs"


### PR DESCRIPTION
移除skip-node-setup和artifacts-path配置项，这些配置在当前workflow中未被使用